### PR TITLE
Fix up issues with error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,11 @@ module.exports = function (options) {
 		var self = this;
 
 		protagonist.parse(file.contents.toString(), function (error, result) {
+
+			if (error) {
+				return cb(new PluginError('gulp-snowcrash', error));
+			}
+
 			try {
 
 				var newfile = new gutil.File({
@@ -36,11 +41,11 @@ module.exports = function (options) {
 
 			} catch (e) {
 
-				throw new PluginError('gulp-snowcrash', error);
-				cb(error);
+				cb(new PluginError('gulp-snowcrash', e));
 
 			}
 
 		});
 	});
 };
+


### PR DESCRIPTION
There were a couple of issues with error handling that I came across while using the plugin.

1. Protagonists errors were not being handled
2. The throw before the callback was redundant, so I switched to sending the error back in the callback which gulp can then handle.

Nice work on the plugin, I hope this is useful!