### PR TITLE
Bumped dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports = function (options) {
 					base: file.base,
 					cwd: file.cwd,
 					path: gutil.replaceExtension(file.path, '.' + options.format),
-					contents: new Buffer(JSON.stringify(result.ast, null, 2))
+					contents: new Buffer(JSON.stringify(result, null, 2))
 				});
 
 				self.push(newfile);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/4yopping/gulp-snowcrash",
   "dependencies": {
     "gulp-util": "^3.0.3",
-    "protagonist": "^0.19.0",
-    "through2": "^0.6.3"
+    "protagonist": "^1.2.0",
+    "through2": "^2.0.0"
   }
 }


### PR DESCRIPTION
This PR bumps some of the dependencies of `gulp-snowcrash`, as it was not compatible with later versions of node. For example, installing `gulp-snowcrash` on v4.2.1 of node resulted in the following stack trace. 

It also transitions away from the deprecated [API Blueprint AST](https://github.com/apiaryio/api-blueprint-ast) towards the [API Description Refract Namespace](https://github.com/refractproject/refract-spec/blob/master/namespaces/api-description-namespace.md).

```
> protagonist@0.19.6 install /Users/nicgordon/Sites/ahm-uplift/ahm-api/node_modules/gulp-snowcrash/node_modules/protagonist
> node-gyp rebuild

  CXX(target) Release/obj.target/libmarkdownparser/drafter/ext/snowcrash/ext/markdown-parser/src/ByteBuffer.o
  CXX(target) Release/obj.target/libmarkdownparser/drafter/ext/snowcrash/ext/markdown-parser/src/MarkdownNode.o
  CXX(target) Release/obj.target/libmarkdownparser/drafter/ext/snowcrash/ext/markdown-parser/src/MarkdownParser.o
  LIBTOOL-STATIC Release/markdownparser.a
  CXX(target) Release/obj.target/libsnowcrash/drafter/ext/snowcrash/src/HTTP.o
  CXX(target) Release/obj.target/libsnowcrash/drafter/ext/snowcrash/src/MSON.o
  CXX(target) Release/obj.target/libsnowcrash/drafter/ext/snowcrash/src/MSONOneOfParser.o
  CXX(target) Release/obj.target/libsnowcrash/drafter/ext/snowcrash/src/MSONSourcemap.o
  CXX(target) Release/obj.target/libsnowcrash/drafter/ext/snowcrash/src/MSONTypeSectionParser.o
  CXX(target) Release/obj.target/libsnowcrash/drafter/ext/snowcrash/src/MSONValueMemberParser.o
  CXX(target) Release/obj.target/libsnowcrash/drafter/ext/snowcrash/src/Blueprint.o
  CXX(target) Release/obj.target/libsnowcrash/drafter/ext/snowcrash/src/BlueprintSourcemap.o
  CXX(target) Release/obj.target/libsnowcrash/drafter/ext/snowcrash/src/Section.o
  CXX(target) Release/obj.target/libsnowcrash/drafter/ext/snowcrash/src/Signature.o
  CXX(target) Release/obj.target/libsnowcrash/drafter/ext/snowcrash/src/snowcrash.o
  CXX(target) Release/obj.target/libsnowcrash/drafter/ext/snowcrash/src/UriTemplateParser.o
  CXX(target) Release/obj.target/libsnowcrash/drafter/ext/snowcrash/src/HeadersParser.o
  CXX(target) Release/obj.target/libsnowcrash/drafter/ext/snowcrash/src/posix/RegexMatch.o
  LIBTOOL-STATIC Release/snowcrash.a
  CC(target) Release/obj.target/libsundown/drafter/ext/snowcrash/ext/markdown-parser/ext/sundown/src/autolink.o
  CC(target) Release/obj.target/libsundown/drafter/ext/snowcrash/ext/markdown-parser/ext/sundown/src/buffer.o
  CC(target) Release/obj.target/libsundown/drafter/ext/snowcrash/ext/markdown-parser/ext/sundown/src/markdown.o
  CC(target) Release/obj.target/libsundown/drafter/ext/snowcrash/ext/markdown-parser/ext/sundown/src/src_map.o
  CC(target) Release/obj.target/libsundown/drafter/ext/snowcrash/ext/markdown-parser/ext/sundown/src/stack.o
  CC(target) Release/obj.target/libsundown/drafter/ext/snowcrash/ext/markdown-parser/ext/sundown/html/houdini_href_e.o
  CC(target) Release/obj.target/libsundown/drafter/ext/snowcrash/ext/markdown-parser/ext/sundown/html/houdini_html_e.o
  CC(target) Release/obj.target/libsundown/drafter/ext/snowcrash/ext/markdown-parser/ext/sundown/html/html.o
  CC(target) Release/obj.target/libsundown/drafter/ext/snowcrash/ext/markdown-parser/ext/sundown/html/html_smartypants.o
  LIBTOOL-STATIC Release/sundown.a
  CXX(target) Release/obj.target/libdrafter/drafter/src/drafter.o
  CXX(target) Release/obj.target/libdrafter/drafter/src/cdrafter.o
  CXX(target) Release/obj.target/libdrafter/drafter/src/Serialize.o
  CXX(target) Release/obj.target/libdrafter/drafter/src/SerializeAST.o
  CXX(target) Release/obj.target/libdrafter/drafter/src/SerializeSourcemap.o
  CXX(target) Release/obj.target/libdrafter/drafter/src/SerializeResult.o
  LIBTOOL-STATIC Release/drafter.a
  CXX(target) Release/obj.target/libsos/drafter/ext/sos/src/sos.o
  LIBTOOL-STATIC Release/sos.a
  CXX(target) Release/obj.target/protagonist/src/annotation.o
In file included from ../src/annotation.cc:1:
In file included from ../src/protagonist.h:6:
../node_modules/nan/nan.h:261:25: error: redefinition of '_NanEnsureLocal'
NAN_INLINE v8::Local<T> _NanEnsureLocal(v8::Local<T> val) {
                        ^
../node_modules/nan/nan.h:256:25: note: previous definition is here
NAN_INLINE v8::Local<T> _NanEnsureLocal(v8::Handle<T> val) {
                        ^
../node_modules/nan/nan.h:661:13: error: no member named 'smalloc' in namespace 'node'
    , node::smalloc::FreeCallback callback
      ~~~~~~^
../node_modules/nan/nan.h:672:12: error: no matching function for call to 'New'
    return node::Buffer::New(v8::Isolate::GetCurrent(), data, size);
           ^~~~~~~~~~~~~~~~~
/Users/nicgordon/.node-gyp/4.2.1/include/node/node_buffer.h:31:40: note: candidate function not viable: no known conversion from
      'uint32_t' (aka 'unsigned int') to 'enum encoding' for 3rd argument
NODE_EXTERN v8::MaybeLocal<v8::Object> New(v8::Isolate* isolate,
                                       ^
/Users/nicgordon/.node-gyp/4.2.1/include/node/node_buffer.h:43:40: note: candidate function not viable: 2nd argument ('const char *')
      would lose const qualifier
NODE_EXTERN v8::MaybeLocal<v8::Object> New(v8::Isolate* isolate,
                                       ^
/Users/nicgordon/.node-gyp/4.2.1/include/node/node_buffer.h:28:40: note: candidate function not viable: requires 2 arguments, but 3 were
      provided
NODE_EXTERN v8::MaybeLocal<v8::Object> New(v8::Isolate* isolate, size_t length);
                                       ^
/Users/nicgordon/.node-gyp/4.2.1/include/node/node_buffer.h:36:40: note: candidate function not viable: requires 5 arguments, but 3 were
      provided
NODE_EXTERN v8::MaybeLocal<v8::Object> New(v8::Isolate* isolate,
                                       ^
In file included from ../src/annotation.cc:1:
In file included from ../src/protagonist.h:6:
../node_modules/nan/nan.h:676:12: error: no viable conversion from 'v8::MaybeLocal<v8::Object>' to 'v8::Local<v8::Object>'
    return node::Buffer::New(v8::Isolate::GetCurrent(), size);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/nicgordon/.node-gyp/4.2.1/include/node/v8.h:210:7: note: candidate constructor (the implicit copy constructor) not viable: no
      known conversion from 'v8::MaybeLocal<v8::Object>' to 'const v8::Local<v8::Object> &' for 1st argument
class Local {
      ^
/Users/nicgordon/.node-gyp/4.2.1/include/node/v8.h:210:7: note: candidate constructor (the implicit move constructor) not viable: no
      known conversion from 'v8::MaybeLocal<v8::Object>' to 'v8::Local<v8::Object> &&' for 1st argument
class Local {
      ^
/Users/nicgordon/.node-gyp/4.2.1/include/node/v8.h:214:13: note: candidate template ignored: could not match 'Local' against 'MaybeLocal'
  V8_INLINE Local(Local<S> that)
            ^
/Users/nicgordon/.node-gyp/4.2.1/include/node/v8.h:326:13: note: candidate template ignored: could not match 'S *' against
      'v8::MaybeLocal<v8::Object>'
  V8_INLINE Local(S* that)
            ^
In file included from ../src/annotation.cc:1:
In file included from ../src/protagonist.h:6:
../node_modules/nan/nan.h:683:26: error: no member named 'Use' in namespace 'node::Buffer'
    return node::Buffer::Use(v8::Isolate::GetCurrent(), data, size);
           ~~~~~~~~~~~~~~^
In file included from ../src/annotation.cc:1:
In file included from ../src/protagonist.h:4:
In file included from /Users/nicgordon/.node-gyp/4.2.1/include/node/node.h:42:
/Users/nicgordon/.node-gyp/4.2.1/include/node/v8.h:221:5: error: assigning to 'v8::Primitive *volatile' from incompatible type
      'v8::Value *'
    TYPE_CHECK(T, S);
    ^~~~~~~~~~~~~~~~
/Users/nicgordon/.node-gyp/4.2.1/include/node/v8.h:180:37: note: expanded from macro 'TYPE_CHECK'
    *(static_cast<T* volatile*>(0)) = static_cast<S*>(0);      \
                                    ^ ~~~~~~~~~~~~~~~~~~
../node_modules/nan/nan.h:414:12: note: in instantiation of function template specialization 'v8::Local<v8::Primitive>::Local<v8::Value>'
      requested here
    return NanEscapeScope(NanNew(v8::Undefined(v8::Isolate::GetCurrent())));
           ^
../node_modules/nan/nan.h:398:30: note: expanded from macro 'NanEscapeScope'
# define NanEscapeScope(val) scope.Escape(_NanEnsureLocal(val))
                             ^
In file included from ../src/annotation.cc:1:
In file included from ../src/protagonist.h:4:
In file included from /Users/nicgordon/.node-gyp/4.2.1/include/node/node.h:42:
/Users/nicgordon/.node-gyp/4.2.1/include/node/v8.h:221:5: error: assigning to 'v8::Boolean *volatile' from incompatible type
      'v8::Value *'
    TYPE_CHECK(T, S);
    ^~~~~~~~~~~~~~~~
/Users/nicgordon/.node-gyp/4.2.1/include/node/v8.h:180:37: note: expanded from macro 'TYPE_CHECK'
    *(static_cast<T* volatile*>(0)) = static_cast<S*>(0);      \
                                    ^ ~~~~~~~~~~~~~~~~~~
../node_modules/nan/nan.h:424:12: note: in instantiation of function template specialization 'v8::Local<v8::Boolean>::Local<v8::Value>'
      requested here
    return NanEscapeScope(NanNew(v8::True(v8::Isolate::GetCurrent())));
           ^
../node_modules/nan/nan.h:398:30: note: expanded from macro 'NanEscapeScope'
# define NanEscapeScope(val) scope.Escape(_NanEnsureLocal(val))
                             ^
In file included from ../src/annotation.cc:1:
In file included from ../src/protagonist.h:4:
In file included from /Users/nicgordon/.node-gyp/4.2.1/include/node/node.h:42:
/Users/nicgordon/.node-gyp/4.2.1/include/node/v8.h:221:5: error: assigning to 'v8::Function *volatile' from incompatible type
      'v8::Value *'
    TYPE_CHECK(T, S);
    ^~~~~~~~~~~~~~~~
/Users/nicgordon/.node-gyp/4.2.1/include/node/v8.h:180:37: note: expanded from macro 'TYPE_CHECK'
    *(static_cast<T* volatile*>(0)) = static_cast<S*>(0);      \
                                    ^ ~~~~~~~~~~~~~~~~~~
../node_modules/nan/nan.h:1514:12: note: in instantiation of function template specialization 'v8::Local<v8::Function>::Local<v8::Value>'
      requested here
    return NanEscapeScope(NanNew(handle)->Get(kCallbackIndex)
           ^
../node_modules/nan/nan.h:398:30: note: expanded from macro 'NanEscapeScope'
# define NanEscapeScope(val) scope.Escape(_NanEnsureLocal(val))
                             ^
In file included from ../src/annotation.cc:1:
In file included from ../src/protagonist.h:4:
In file included from /Users/nicgordon/.node-gyp/4.2.1/include/node/node.h:42:
/Users/nicgordon/.node-gyp/4.2.1/include/node/v8.h:221:5: error: assigning to 'v8::Object *volatile' from incompatible type 'v8::Value *'
    TYPE_CHECK(T, S);
    ^~~~~~~~~~~~~~~~
/Users/nicgordon/.node-gyp/4.2.1/include/node/v8.h:180:37: note: expanded from macro 'TYPE_CHECK'
    *(static_cast<T* volatile*>(0)) = static_cast<S*>(0);      \
                                    ^ ~~~~~~~~~~~~~~~~~~
../node_modules/nan/nan.h:1632:12: note: in instantiation of function template specialization 'v8::Local<v8::Object>::Local<v8::Value>'
      requested here
    return NanEscapeScope(handle->Get(NanNew(key)).As<v8::Object>());
           ^
../node_modules/nan/nan.h:398:30: note: expanded from macro 'NanEscapeScope'
# define NanEscapeScope(val) scope.Escape(_NanEnsureLocal(val))
                             ^
9 errors generated.
```